### PR TITLE
add a redirect to e3sm docs

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Install python deps
-        run: python3 -m pip install mkdocs-material pymdown-extensions mkdocs-monorepo-plugin mdutils mkdocs-bibtex
+        run: python3 -m pip install mkdocs-material pymdown-extensions mkdocs-monorepo-plugin mdutils mkdocs-bibtex mkdocs-redirects
       # build every time (PR or push to master)
       - name: Build
         run: mkdocs build --strict --verbose

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -34,3 +34,8 @@ extra_javascript:
   - javascript/mathjax.js
   - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+
+plugins:
+  - redirects:
+      redirect_maps:
+        'Docs.md': 'https://e3sm-project.github.io/E3SM'

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,5 +1,8 @@
 site_name: E3SM-Project
 
+nav:
+  - 'E3SM Docs': 'https://e3sm-project.github.io/E3SM'
+
 theme:
   name: material
   palette:
@@ -38,4 +41,4 @@ extra_javascript:
 plugins:
   - redirects:
       redirect_maps:
-        'Docs.md': 'https://e3sm-project.github.io/E3SM'
+        'e3sm.md': 'https://e3sm-project.github.io/E3SM'


### PR DESCRIPTION
Fixes an issue Rob brought up a while back about the limitation of github pages not working correctly for uppercase/lowercase. This PR fixes that by adding a redirect to the docs page.

Before this PR:
```
https://e3sm-project.github.io/e3sm ----> 404
https://e3sm-project.github.io/E3SM ----> works
```

After this PR:
```
https://e3sm-project.github.io/e3sm ----> works
https://e3sm-project.github.io/E3SM ----> works
```