### PR TITLE
Update internal links

### DIFF
--- a/docs/running-e3sm-guide/guide-documenting.md
+++ b/docs/running-e3sm-guide/guide-documenting.md
@@ -3,7 +3,7 @@
 !!! warning
     This section only applies to E3SM staff only.
 
-You should create a Confluence page for your model run in the relevant Confluence space. Use the [Simulation Run Template](https://acme-climate.atlassian.net/wiki/spaces/EWCG/pages/2297299190) as a template. See below for how to fill out this template.
+You should create a Confluence page for your model run in the relevant Confluence space. Use the [Simulation Run Template](https://acme-climate.atlassian.net/wiki/spaces/DOC/pages/4298211329/Example+Simulation+Run+Template+Water+Cycle+v2) as a template. See below for how to fill out this template.
 
 <!-- TODO: where should the Confluence pages be made for v3 (and for each group)? -->
 

--- a/docs/running-e3sm-guide/guide-long-term-archiving.md
+++ b/docs/running-e3sm-guide/guide-long-term-archiving.md
@@ -186,7 +186,7 @@ $ ls /home/<first letter>/<username>/E3SMv2/<case_name>
 $ exit
 ```
 
-If you are E3SM staff, update the simulation Confluence page with information regarding this simulation (For Water Cycle’s v2 work, that page is [V2 Simulation Planning](https://acme-climate.atlassian.net/wiki/spaces/ED/pages/2766340117)). In the `zstash archive` column, specify:
+If you are E3SM staff, update the (internal) simulation Confluence page with information regarding this simulation (For v3 work, that page is [V3 Simulation Planning](https://acme-climate.atlassian.net/wiki/spaces/ED/pages/4282679297/V3+Simulation+Planning)). In the `zstash archive` column, specify:
 
 - `/home/<first letter>/<username>/E3SMv2/<case_name>`
 - `zstash_create_<stamp>.log`

--- a/docs/running-e3sm-guide/guide-publishing.md
+++ b/docs/running-e3sm-guide/guide-publishing.md
@@ -1,3 +1,3 @@
 # Publishing
 
-The E3SM Project has a policy to publish all official simulation campaigns once those simulations are documented in publications. Refer to step 3 in [Simulation Data Management](https://acme-climate.atlassian.net/wiki/spaces/DOC/pages/1159594096) for guidance on requesting data publication.
+The E3SM Project has a policy to publish all official simulation campaigns once those simulations are documented in publications. If you are E3SM staff, refer to step 3 in [Simulation Data Management](https://acme-climate.atlassian.net/wiki/spaces/DOC/pages/1159594096) for guidance on requesting data publication.


### PR DESCRIPTION
Update internal links. @mccoy20 requested the documentation be checked for internal links.

```
$ git grep -n atlassian
guide-documenting.md:6:You should create a Confluence page for your model run in the relevant Confluence space. Use the [Simulation Run Template](https://acme-climate.atlassian.net/wiki/spaces/EWCG/pages/2297299190) as a template. See below for how to fill out this template.
guide-long-term-archiving.md:189:If you are E3SM staff, update the simulation Confluence page with information regarding this simulation (For Water Cycle’s v2 work, that page is [V2 Simulation Planning](https://acme-climate.atlassian.net/wiki/spaces/ED/pages/2766340117)). In the `zstash archive` column, specify:
guide-publishing.md:3:The E3SM Project has a policy to publish all official simulation campaigns once those simulations are documented in publications. Refer to step 3 in [Simulation Data Management](https://acme-climate.atlassian.net/wiki/spaces/DOC/pages/1159594096) for guidance on requesting data publication.
```
I have checked these 3 links -- either updating, or adding context.