### PR TITLE
explicitly enable search plugin

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -81,6 +81,7 @@ extra:
     property: G-P3Z7LHMQE3
 
 plugins:
+  - search
   - redirects:
       redirect_maps:
         'e3sm.md': 'https://e3sm-project.github.io/E3SM'


### PR DESCRIPTION
the search plugin needs to be explicitly enabled per the mkdocs documentation:

> it's enabled by default, but must be re-added to mkdocs.yml when other plugins are used

https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/#built-in-search-plugin